### PR TITLE
Enable chat input even when agents are offline

### DIFF
--- a/LiveChat/index.js
+++ b/LiveChat/index.js
@@ -377,9 +377,6 @@ export default class LiveChat extends Component {
 	}
 
 	shouldDisableComposer = () => {
-		if (!this.state.onlineStatus && !this.state.chatActive) {
-			return true
-		}
 		if (this.state.queued) {
 			return true
 		}


### PR DESCRIPTION
NOTE: this _might_ be better as a prop so client code can pass a value matching their `Messaging Mode` setting, but we'll always have that set to true
https://www.livechat.com/messaging-mode/