### PR TITLE
Store chat id instead of whole chat object on initial chat create

### DIFF
--- a/LiveChat/index.js
+++ b/LiveChat/index.js
@@ -132,7 +132,7 @@ export default class LiveChat extends Component {
 				})
 				.then((chat) => {
 					this.setState({
-						chatId: chat.chat,
+						chatId: chat.chat.id,
 						chatActive: true,
 					})
 				})


### PR DESCRIPTION
If the user already has a chat, their most recent one is loaded when the chat widget initializes. If they don't, it's created when they try to send their first message. In that latter case, the library code was incorrectly storing the ID of the newly created chat, causing subsequent messages to fail. (It was storing the whole chat where the id belongs.)